### PR TITLE
Update UI to simplify downloads

### DIFF
--- a/index.html
+++ b/index.html
@@ -69,7 +69,7 @@
         </div>
 
         <!-- Main Content -->
-        <div class="grid md:grid-cols-2 lg:grid-cols-3 gap-8">
+        <div class="grid grid-cols-1 gap-8">
             <!-- Input Section -->
             <div class="space-y-6">
                 <div class="bg-gradient-to-br from-white to-gray-50 dark:from-gray-800 dark:to-gray-900 rounded-2xl p-8 border border-gray-200 dark:border-gray-700 shadow-lg">
@@ -311,12 +311,7 @@ CREATE TABLE posts (
                                     </svg>
                                     Download ZIP
                                 </button>
-                                <button id="downloadBtn" class="px-6 py-2 bg-primary text-white rounded-xl hover:bg-primary-dark transition-colors disabled:opacity-50 disabled:cursor-not-allowed shadow-lg flex items-center" disabled="">
-                                    <svg class="w-4 h-4 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 10v6m0 0l-3-3m3 3l3-3M4 16l8 8 8-8"></path>
-                                    </svg>
-                                    Download Files
-                                </button>
+                                
                             </div>
                         </h2>
                         <p class="text-gray-600 dark:text-gray-400 mt-2">Your generated NestJS application will appear here</p>
@@ -1633,7 +1628,6 @@ ${config.includeDocker ? `├── 🐳 Dockerfile
 
                 // Show success state
                 showSuccessState();
-                document.getElementById('downloadBtn').disabled = false;
                 document.getElementById('downloadZipBtn').disabled = false;
 
             } catch (error) {
@@ -1660,29 +1654,6 @@ ${config.includeDocker ? `├── 🐳 Dockerfile
         // Event listeners
         document.getElementById('generateBtn').addEventListener('click', generateNestJSApp);
 
-        document.getElementById('downloadBtn').addEventListener('click', () => {
-            // Create combined file content
-            let content = `# ${document.getElementById('appName').value} - NestJS Application\n`;
-            content += `# Generated on ${new Date().toISOString()}\n\n`;
-            
-            for (const [fileName, fileContent] of Object.entries(generatedFiles)) {
-                if (fileName !== 'structure') {
-                    content += `\n${'='.repeat(80)}\n`;
-                    content += `# File: ${fileName}\n`;
-                    content += `${'='.repeat(80)}\n\n`;
-                    content += fileContent;
-                    content += '\n\n';
-                }
-            }
-            
-            const blob = new Blob([content], { type: 'text/plain' });
-            const url = URL.createObjectURL(blob);
-            const a = document.createElement('a');
-            a.href = url;
-            a.download = `${document.getElementById('appName').value}-nestjs-application.txt`;
-            a.click();
-            URL.revokeObjectURL(url);
-        });
 
         document.getElementById('downloadZipBtn').addEventListener('click', async () => {
             const appName = document.getElementById('appName').value;
@@ -1719,6 +1690,8 @@ ${config.includeDocker ? `├── 🐳 Dockerfile
             a.download = `${appName}-complete-application.zip`;
             a.click();
             URL.revokeObjectURL(url);
+            document.querySelectorAll(".file-tab:not([data-file="structure"])").forEach(tab => tab.remove());
+            showFile("structure");
         });
 
         // Initialize with project structure tab


### PR DESCRIPTION
## Summary
- show cards one per row
- remove obsolete `Download Files` button
- hide extra tabs after downloading ZIP

## Testing
- `npm test` *(fails: Could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_b_686bc3c9e0f88325b22d3e5427c098b1