### PR TITLE
Fix missing closing quote in JS selector

### DIFF
--- a/index.html
+++ b/index.html
@@ -1690,7 +1690,7 @@ ${config.includeDocker ? `├── 🐳 Dockerfile
             a.download = `${appName}-complete-application.zip`;
             a.click();
             URL.revokeObjectURL(url);
-            document.querySelectorAll(".file-tab:not([data-file="structure"])").forEach(tab => tab.remove());
+            document.querySelectorAll('.file-tab:not([data-file="structure"])').forEach(tab => tab.remove());
             showFile("structure");
         });
 


### PR DESCRIPTION
## Summary
- fix double quote usage in `document.querySelectorAll` call

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_686bc53a49288325a8bf1624c475361b